### PR TITLE
Refactor graph builder instruction annotations processing.

### DIFF
--- a/gematria/granite/graph_builder.cc
+++ b/gematria/granite/graph_builder.cc
@@ -34,6 +34,7 @@ namespace {
 
 constexpr BasicBlockGraphBuilder::NodeIndex kInvalidNode(-1);
 constexpr BasicBlockGraphBuilder::TokenIndex kInvalidTokenIndex(-1);
+constexpr double kDefaultInstructionAnnotation(-1);
 
 std::unordered_map<std::string, BasicBlockGraphBuilder::TokenIndex> MakeIndex(
     std::vector<std::string> items) {
@@ -172,7 +173,7 @@ BasicBlockGraphBuilder::BasicBlockGraphBuilder(
               : FindTokenOrDie(
                     node_tokens_,
                     out_of_vocabulary_behavior.replacement_token())) {
-  instruction_annotations_ = std::vector<std::vector<float>>();
+  instruction_annotations_ = std::vector<std::vector<double>>();
 
   // Make sure annotations are stored in a stable order as long the same
   // annotation names are used.
@@ -183,7 +184,7 @@ BasicBlockGraphBuilder::BasicBlockGraphBuilder(
 
   // Store row indices corresponding to specific annotation names.
   int annotation_idx = 0;
-  for (auto& annotation_name : annotation_names_) {
+  for (const std::string& annotation_name : annotation_names_) {
     annotation_name_to_idx_[annotation_name] = annotation_idx;
     ++annotation_idx;
   }
@@ -198,15 +199,8 @@ BasicBlockGraphBuilder::NodeIndex BasicBlockGraphBuilder::AddInstruction(
     return kInvalidNode;
   }
 
-  // Store the annotations for later use (inclusion in embeddings), using -1
-  // as a default value wherever annotations are missing.
-  std::vector<float> row = std::vector<float>(annotation_names_.size(), -1);
-  for (const auto& [name, value] : instruction.instruction_annotations) {
-    const auto annotation_index = annotation_name_to_idx_.find(name);
-    if (annotation_index == annotation_name_to_idx_.end()) continue;
-    row[annotation_index->second] = value;
-  }
-  instruction_annotations_.push_back(row);
+  // Store instruction annotations.
+  AddInstructionAnnotations(instruction);
 
   // Add nodes for prefixes of the instruction.
   for (const std::string& prefix : instruction.prefixes) {
@@ -449,6 +443,20 @@ void BasicBlockGraphBuilder::AddEdge(EdgeType edge_type, NodeIndex sender,
   edge_senders_.push_back(sender);
   edge_receivers_.push_back(receiver);
   edge_types_.push_back(edge_type);
+}
+
+void BasicBlockGraphBuilder::AddInstructionAnnotations(
+    const Instruction& instruction) {
+  // Store the annotations for later use, using `kDefaultInstructionAnnotation`
+  // as a default value wherever annotations are missing.
+  std::vector<double> row = std::vector<double>(annotation_names_.size(),
+                                              kDefaultInstructionAnnotation);
+  for (const auto& [name, value] : instruction.instruction_annotations) {
+    const auto annotation_index = annotation_name_to_idx_.find(name);
+    if (annotation_index == annotation_name_to_idx_.end()) continue;
+    row[annotation_index->second] = value;
+  }
+  instruction_annotations_.push_back(row);
 }
 
 std::vector<int> BasicBlockGraphBuilder::EdgeFeatures() const {

--- a/gematria/granite/graph_builder.h
+++ b/gematria/granite/graph_builder.h
@@ -91,7 +91,6 @@
 
 #include <cstddef>
 #include <ostream>
-#include <set>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -251,7 +250,7 @@ class BasicBlockGraphBuilder {
   // `num_instructions` x `annotation_names.size()` matrix, each entry of which
   // represents the value of the annotation of the type corresponding to the
   // column for the instruction corresponding to the row.
-  const std::vector<std::vector<float>>& instruction_annotations() const {
+  const std::vector<std::vector<double>>& instruction_annotations() const {
     return instruction_annotations_;
   }
 
@@ -387,6 +386,10 @@ class BasicBlockGraphBuilder {
   // Adds a new edge to the batch.
   void AddEdge(EdgeType edge_type, NodeIndex sender, NodeIndex receiver);
 
+  // Updates the `instruction_annotations_` tensor with annotations from
+  // `instruction`.
+  void AddInstructionAnnotations(const Instruction& instruction);
+
   // Mapping from string node tokens to indices of embedding vectors used in
   // the models.
   const std::unordered_map<std::string, TokenIndex> node_tokens_;
@@ -414,7 +417,7 @@ class BasicBlockGraphBuilder {
   // Mapping from annotation type names to corresponding row index in the
   // `instruction_annotations_` matrix.
   std::unordered_map<std::string, int> annotation_name_to_idx_;
-  std::vector<std::vector<float>> instruction_annotations_;
+  std::vector<std::vector<double>> instruction_annotations_;
 
   std::vector<NodeIndex> edge_senders_;
   std::vector<NodeIndex> edge_receivers_;

--- a/gematria/granite/graph_builder_model_inference.cc
+++ b/gematria/granite/graph_builder_model_inference.cc
@@ -676,7 +676,7 @@ GraphBuilderModelInference::RunInference() {
 
   const std::vector<bool> instruction_node_mask =
       graph_builder_->InstructionNodeMask();
-  const std::vector<std::vector<float>>& instruction_annotations =
+  const std::vector<std::vector<double>>& instruction_annotations =
       graph_builder_->instruction_annotations();
   const std::vector<int> delta_block_index = graph_builder_->DeltaBlockIndex();
 
@@ -769,7 +769,7 @@ GraphBuilderModelInference::RunInference() {
         input_tensor_to_idx_[static_cast<int>(InputTensor::kDeltaBlockIndex)]));
   }
   if (uses_annotations_) {
-    GEMATRIA_RETURN_IF_ERROR(FillTensorFromStdVectorMatrix<float>(
+    GEMATRIA_RETURN_IF_ERROR(FillTensorFromStdVectorMatrix<double>(
         interpreter_.get(), instruction_annotations,
         input_tensor_to_idx_[static_cast<int>(
             InputTensor::kInstructionAnnotations)]));
@@ -806,7 +806,7 @@ GraphBuilderModelInference::RunInference() {
                                    output_tensor->dims->data[0]);
   }
   const int num_tasks = output_tensor->dims->data[1];
-  auto* const output_tensor_data = interpreter_->typed_output_tensor<float>(0);
+  auto* const output_tensor_data = interpreter_->typed_output_tensor<double>(0);
   assert(output_tensor_data != nullptr);
 
   std::vector<OutputType> output;


### PR DESCRIPTION
 * Move annotation adding logic to `AddInstructionAnnotations`.
 * Use `double` consistently.
 * Remove default annotation magic number.